### PR TITLE
Enable Firebase leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,20 @@ To run tests in Node:
 ```js
 npm test
 ```
+
+## High Score Leaderboard
+
+This project now includes simple Firebase hooks to store scores. Provide your
+Firebase project credentials in `firebase-leaderboard.js`:
+
+```
+var firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_APP.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+```
+
+The free tier of Firebase is sufficient for small projects. When the game ends,
+your score is written to Firestore and the top five scores are displayed inside
+the `#high-scores` div.

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ npm test
 ## High Score Leaderboard
 
 This project now includes simple Firebase hooks to store scores. Provide your
-Firebase project credentials in `firebase-leaderboard.js`:
+Firebase project credentials in `firebase-leaderboard.js` or supply them at
+runtime using a `FIREBASE_CONFIG` variable:
 
 ```
-var firebaseConfig = {
+var defaultConfig = {
   apiKey: "YOUR_API_KEY",
   authDomain: "YOUR_APP.firebaseapp.com",
   projectId: "YOUR_PROJECT_ID"
 };
+var firebaseConfig = window.FIREBASE_CONFIG || defaultConfig;
 ```
 
 The free tier of Firebase is sufficient for small projects. When the game ends,

--- a/README.md
+++ b/README.md
@@ -32,18 +32,23 @@ npm test
 
 ## High Score Leaderboard
 
-This project now includes simple Firebase hooks to store scores. Provide your
-Firebase project credentials in `firebase-leaderboard.js` or supply them at
-runtime using a `FIREBASE_CONFIG` variable:
+This project now includes simple Firebase hooks to store scores. The
+configuration is hard-coded in `firebase-leaderboard.js` for a public demo
+project:
 
 ```
-var defaultConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_APP.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
+var firebaseConfig = {
+  apiKey: "AIzaSyAnW89Ydx9-6PA6zgOiyi5LC3fGDM75Lug",
+  authDomain: "asteroids-high-scores-f6c47.firebaseapp.com",
+  projectId: "asteroids-high-scores-f6c47",
+  storageBucket: "asteroids-high-scores-f6c47.firebasestorage.app",
+  messagingSenderId: "52296295518",
+  appId: "1:52296295518:web:c98a3998c6b37fcae680cf"
 };
-var firebaseConfig = window.FIREBASE_CONFIG || defaultConfig;
 ```
+
+Feel free to edit these values with your own Firebase project credentials if
+you wish to use a different backend.
 
 The free tier of Firebase is sufficient for small projects. When the game ends,
 your score is written to Firestore and the top five scores are displayed inside

--- a/firebase-leaderboard.js
+++ b/firebase-leaderboard.js
@@ -1,12 +1,13 @@
 // Firebase setup for high-score leaderboard
 // Load Firebase scripts before this file.
 
-// Replace with your Firebase project configuration
-var firebaseConfig = {
+// Replace with your Firebase project configuration or set FIREBASE_CONFIG
+var defaultConfig = {
   apiKey: "YOUR_API_KEY",
   authDomain: "YOUR_APP.firebaseapp.com",
   projectId: "YOUR_PROJECT_ID"
 };
+var firebaseConfig = window.FIREBASE_CONFIG || defaultConfig;
 
 if (!window.firebase.apps.length) {
   window.firebase.initializeApp(firebaseConfig);

--- a/firebase-leaderboard.js
+++ b/firebase-leaderboard.js
@@ -1,0 +1,37 @@
+// Firebase setup for high-score leaderboard
+// Load Firebase scripts before this file.
+
+// Replace with your Firebase project configuration
+var firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_APP.firebaseapp.com",
+  projectId: "YOUR_PROJECT_ID"
+};
+
+if (!window.firebase.apps.length) {
+  window.firebase.initializeApp(firebaseConfig);
+}
+var db = window.firebase.firestore();
+
+window.saveScore = function(score, level) {
+  return db.collection('scores').add({
+    score: score,
+    level: level,
+    created: window.firebase.firestore.FieldValue.serverTimestamp()
+  });
+};
+
+window.loadScores = function() {
+  return db.collection('scores')
+    .orderBy('score', 'desc')
+    .limit(5)
+    .get()
+    .then(function(query) {
+      var list = '';
+      query.forEach(function(doc) {
+        var data = doc.data();
+        list += '<div>' + data.score + '</div>';
+      });
+      document.getElementById('high-scores').innerHTML = list;
+    });
+};

--- a/firebase-leaderboard.js
+++ b/firebase-leaderboard.js
@@ -1,13 +1,15 @@
 // Firebase setup for high-score leaderboard
 // Load Firebase scripts before this file.
 
-// Replace with your Firebase project configuration or set FIREBASE_CONFIG
-var defaultConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_APP.firebaseapp.com",
-  projectId: "YOUR_PROJECT_ID"
+// Hard-coded Firebase configuration for the public demo project
+var firebaseConfig = {
+  apiKey: "AIzaSyAnW89Ydx9-6PA6zgOiyi5LC3fGDM75Lug",
+  authDomain: "asteroids-high-scores-f6c47.firebaseapp.com",
+  projectId: "asteroids-high-scores-f6c47",
+  storageBucket: "asteroids-high-scores-f6c47.firebasestorage.app",
+  messagingSenderId: "52296295518",
+  appId: "1:52296295518:web:c98a3998c6b37fcae680cf"
 };
-var firebaseConfig = window.FIREBASE_CONFIG || defaultConfig;
 
 if (!window.firebase.apps.length) {
   window.firebase.initializeApp(firebaseConfig);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8">
   <title>Asteroids</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/js/materialize.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/css/materialize.min.css">
   <link rel="stylesheet" href="css/style.css">
@@ -28,6 +30,7 @@
     </div>
   </div>
 </div>
+<script src="firebase-leaderboard.js"></script>
 <script src="main.bundle.js"></script>
 </body>
 </html>

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -3,6 +3,9 @@ var context   = canvas.getContext('2d');
 var Game      = require('./game.js');
 
 var game      = new Game(canvas, context);
+if (window.loadScores) {
+    window.loadScores();
+}
 renderWelcomeScreen();
 
 function listen () {

--- a/lib/game.js
+++ b/lib/game.js
@@ -122,6 +122,11 @@ Game.prototype.gameOver = function () {
         + this.level
         + '<br><br>Press Enter to restart</p></div>'
     );
-    //var newScore = "<div>Player: " + this.score + "</div>";
-    //$('#high-scores').append(newScore);
+    if (window.saveScore) {
+        window.saveScore(this.score, this.level).then(function () {
+            if (window.loadScores) {
+                window.loadScores();
+            }
+        });
+    }
 };

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -50,8 +50,11 @@
 	var context = canvas.getContext('2d');
 	var Game = __webpack_require__(1);
 
-	var game = new Game(canvas, context);
-	renderWelcomeScreen();
+var game = new Game(canvas, context);
+if (window.loadScores) {
+    window.loadScores();
+}
+renderWelcomeScreen();
 
 	function listen() {
 	    requestAnimationFrame(function gameLoop() {
@@ -288,14 +291,19 @@
 	    return this;
 	};
 
-	Game.prototype.gameOver = function () {
-	    this.playing = false;
-	    this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-	    $('#game').toggle();
-	    $('#game-window').append('<div id="game-over"><p>GAME OVER<br>Score: ' + this.score + '<br>Level: ' + this.level + '<br><br>Press Enter to restart</p></div>');
-	    //var newScore = "<div>Player: " + this.score + "</div>";
-	    //$('#high-scores').append(newScore);
-	};
+        Game.prototype.gameOver = function () {
+            this.playing = false;
+            this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+            $('#game').toggle();
+            $('#game-window').append('<div id="game-over"><p>GAME OVER<br>Score: ' + this.score + '<br>Level: ' + this.level + '<br><br>Press Enter to restart</p></div>');
+            if (window.saveScore) {
+                window.saveScore(this.score, this.level).then(function () {
+                    if (window.loadScores) {
+                        window.loadScores();
+                    }
+                });
+            }
+        };
 
 /***/ }),
 /* 2 */


### PR DESCRIPTION
## Summary
- load Firebase scripts and leaderboard code
- sync scores to Firestore when the game ends
- automatically load top scores on page load
- document Firebase setup in README

## Testing
- `npm test` *(fails: `./node_modules/mocha/bin/mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f7cee0c28832ea1f0ba36de51a971