### PR TITLE
Enable optional scoreboard integration

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -4,6 +4,9 @@ var Game      = require('./game.js');
 
 var game      = new Game(canvas, context);
 renderWelcomeScreen();
+if (window.loadScores) {
+    window.loadScores();
+}
 
 function listen () {
     requestAnimationFrame(function gameLoop () {

--- a/lib/game.js
+++ b/lib/game.js
@@ -122,6 +122,18 @@ Game.prototype.gameOver = function () {
         + this.level
         + '<br><br>Press Enter to restart</p></div>'
     );
+    if (window.saveScore) {
+        var result = window.saveScore({ score: this.score, level: this.level });
+        if (result && typeof result.then === 'function') {
+            result.then(function () {
+                if (window.loadScores) { window.loadScores(); }
+            });
+        } else if (window.loadScores) {
+            window.loadScores();
+        }
+    } else if (window.loadScores) {
+        window.loadScores();
+    }
     //var newScore = "<div>Player: " + this.score + "</div>";
     //$('#high-scores').append(newScore);
 };


### PR DESCRIPTION
## Summary
- call `window.loadScores()` when the dashboard initializes
- let `gameOver` save the score via `window.saveScore`

## Testing
- `npm run build` *(fails: `./node_modules/webpack/bin/webpack.js: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f8ffb2940832ea3d0548b7c9c4b5f